### PR TITLE
Create Helper Function to Build Instruction Bytes

### DIFF
--- a/test/chip8/instruction/decoder_test.exs
+++ b/test/chip8/instruction/decoder_test.exs
@@ -6,7 +6,7 @@ defmodule Chip8.Instruction.DecoderTest do
 
   describe "decode/1" do
     test "should return a instruction struct for `CLS` instruction" do
-      bytes = [0x00, 0xE0]
+      bytes = build_instruction_bytes(0x00E0)
 
       instruction = Decoder.decode(bytes)
 
@@ -17,7 +17,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for `RET` instruction" do
-      bytes = [0x00, 0xEE]
+      bytes = build_instruction_bytes(0x00EE)
 
       instruction = Decoder.decode(bytes)
 
@@ -28,7 +28,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for `SYS address` instruction" do
-      bytes = [0x0A, 0x4F]
+      bytes = build_instruction_bytes(0x0A4F)
 
       instruction = Decoder.decode(bytes)
 
@@ -39,7 +39,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for `JP address` instruction" do
-      bytes = [0x14, 0xED]
+      bytes = build_instruction_bytes(0x14ED)
 
       instruction = Decoder.decode(bytes)
 
@@ -50,7 +50,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for `CALL address` instruction" do
-      bytes = [0x2B, 0x06]
+      bytes = build_instruction_bytes(0x2B06)
 
       instruction = Decoder.decode(bytes)
 
@@ -61,7 +61,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for `SE Vx, byte` instruction" do
-      bytes = [0x33, 0xA8]
+      bytes = build_instruction_bytes(0x33A8)
 
       instruction = Decoder.decode(bytes)
 
@@ -72,7 +72,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for `SNE Vx, byte` instruction" do
-      bytes = [0x49, 0x8F]
+      bytes = build_instruction_bytes(0x498F)
 
       instruction = Decoder.decode(bytes)
 
@@ -83,7 +83,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SE Vx, Vy` instruction" do
-      bytes = [0x5E, 0x00]
+      bytes = build_instruction_bytes(0x5E00)
 
       instruction = Decoder.decode(bytes)
 
@@ -94,7 +94,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD Vx, byte` instruction" do
-      bytes = [0x66, 0x29]
+      bytes = build_instruction_bytes(0x6629)
 
       instruction = Decoder.decode(bytes)
 
@@ -105,7 +105,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `ADD Vx, byte` instruction" do
-      bytes = [0x75, 0xDB]
+      bytes = build_instruction_bytes(0x75DB)
 
       instruction = Decoder.decode(bytes)
 
@@ -116,7 +116,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD Vx, Vy` instruction" do
-      bytes = [0x89, 0x70]
+      bytes = build_instruction_bytes(0x8970)
 
       instruction = Decoder.decode(bytes)
 
@@ -127,7 +127,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `OR Vx, Vy` instruction" do
-      bytes = [0x8A, 0x31]
+      bytes = build_instruction_bytes(0x8A31)
 
       instruction = Decoder.decode(bytes)
 
@@ -138,7 +138,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `AND Vx, Vy` instruction" do
-      bytes = [0x86, 0xD2]
+      bytes = build_instruction_bytes(0x86D2)
 
       instruction = Decoder.decode(bytes)
 
@@ -149,7 +149,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `XOR Vx, Vy` instruction" do
-      bytes = [0x8C, 0x03]
+      bytes = build_instruction_bytes(0x8C03)
 
       instruction = Decoder.decode(bytes)
 
@@ -160,7 +160,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `ADD Vx, Vy` instruction" do
-      bytes = [0x8F, 0x74]
+      bytes = build_instruction_bytes(0x8F74)
 
       instruction = Decoder.decode(bytes)
 
@@ -171,7 +171,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SUB Vx, Vy` instruction" do
-      bytes = [0x85, 0xB5]
+      bytes = build_instruction_bytes(0x85B5)
 
       instruction = Decoder.decode(bytes)
 
@@ -182,7 +182,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SHR Vx, Vy` instruction" do
-      bytes = [0x8C, 0x96]
+      bytes = build_instruction_bytes(0x8C96)
 
       instruction = Decoder.decode(bytes)
 
@@ -193,7 +193,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SUBN Vx, Vy` instruction" do
-      bytes = [0x83, 0x07]
+      bytes = build_instruction_bytes(0x8307)
 
       instruction = Decoder.decode(bytes)
 
@@ -204,7 +204,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SHL Vx, Vy` instruction" do
-      bytes = [0x8A, 0xEE]
+      bytes = build_instruction_bytes(0x8AEE)
 
       instruction = Decoder.decode(bytes)
 
@@ -215,7 +215,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SNE Vx, Vy` instruction" do
-      bytes = [0x90, 0xD0]
+      bytes = build_instruction_bytes(0x90D0)
 
       instruction = Decoder.decode(bytes)
 
@@ -226,7 +226,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD I, address` instructino" do
-      bytes = [0xA3, 0xFF]
+      bytes = build_instruction_bytes(0xA3FF)
 
       instruction = Decoder.decode(bytes)
 
@@ -236,7 +236,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `JP V0, address` instruction" do
-      bytes = [0xB4, 0x7B]
+      bytes = build_instruction_bytes(0xB47B)
 
       instruction = Decoder.decode(bytes)
 
@@ -247,7 +247,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `RND Vx, byte` instruction" do
-      bytes = [0xC8, 0x6A]
+      bytes = build_instruction_bytes(0xC86A)
 
       instruction = Decoder.decode(bytes)
 
@@ -258,7 +258,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `DRW Vx, Vy, nibble` instruction" do
-      bytes = [0xD7, 0xF2]
+      bytes = build_instruction_bytes(0xD7F2)
 
       instruction = Decoder.decode(bytes)
 
@@ -269,7 +269,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SKP Vx` instruction" do
-      bytes = [0xEC, 0x9E]
+      bytes = build_instruction_bytes(0xEC9E)
 
       instruction = Decoder.decode(bytes)
 
@@ -280,7 +280,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `SKNP Vx` instruction" do
-      bytes = [0xED, 0xA1]
+      bytes = build_instruction_bytes(0xEDA1)
 
       instruction = Decoder.decode(bytes)
 
@@ -291,7 +291,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD Vx, DT` instruction" do
-      bytes = [0xFA, 0x07]
+      bytes = build_instruction_bytes(0xFA07)
 
       instruction = Decoder.decode(bytes)
 
@@ -302,7 +302,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD Vx, K` instruction" do
-      bytes = [0xF5, 0x0A]
+      bytes = build_instruction_bytes(0xF50A)
 
       instruction = Decoder.decode(bytes)
 
@@ -313,7 +313,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD DT, Vy` instruction" do
-      bytes = [0xF3, 0x15]
+      bytes = build_instruction_bytes(0xF315)
 
       instruction = Decoder.decode(bytes)
 
@@ -324,7 +324,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD ST, Vy` instruction" do
-      bytes = [0xFF, 0x18]
+      bytes = build_instruction_bytes(0xFF18)
 
       instruction = Decoder.decode(bytes)
 
@@ -335,7 +335,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `ADD I, Vx` instruction" do
-      bytes = [0xF2, 0x1E]
+      bytes = build_instruction_bytes(0xF21E)
 
       instruction = Decoder.decode(bytes)
 
@@ -346,7 +346,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD F, Vx` instruction" do
-      bytes = [0xF6, 0x29]
+      bytes = build_instruction_bytes(0xF629)
 
       instruction = Decoder.decode(bytes)
 
@@ -357,7 +357,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD B, Vy` instruction" do
-      bytes = [0xF4, 0x33]
+      bytes = build_instruction_bytes(0xF433)
 
       instruction = Decoder.decode(bytes)
 
@@ -368,7 +368,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD I, Vy` instruction" do
-      bytes = [0xFD, 0x55]
+      bytes = build_instruction_bytes(0xFD55)
 
       instruction = Decoder.decode(bytes)
 
@@ -379,7 +379,7 @@ defmodule Chip8.Instruction.DecoderTest do
     end
 
     test "should return a instruction struct for the `LD Vx, I` instruction" do
-      bytes = [0xFF, 0x65]
+      bytes = build_instruction_bytes(0xFF65)
 
       instruction = Decoder.decode(bytes)
 


### PR DESCRIPTION
### Why is this PR necessary?
Create a function to allow to specify an instruction as a 2 bytes integer instead of a list. This allows the test cases to be a little easier to read and understand what is the hex representation of the instruction being tested. This idea occurred to me while implementing the instructions, even though the memory representation is the most reliable one is not easy to read because we have to do a little in-mind decode to understand which instruction is being tested so with this function we move that decode step to the test code.

### What could go wrong?
As with all abstractions, this introduces a complexity to simplify the API, in this case, there's a difference in what the code says and what is happening under the hood, for example, when `0x00E0` is evaluated the runtime won't consider the extra zeroes (`0x0E`) but the code still need those zeroes in order to build the list of bytes that the decoder needs in order to properly decode the instruction.

### What other approaches did you consider? Why did you decide on this approach?
I've opted for using a hexadecimal number as the representation because they are the base for everything in Chip-8 so it felt natural to use it, I could've used a string to represent the instruction, and would be easier to decode but wouldn't be as natural to read IMO.
