### PR TITLE
Fix JP Instruction Flaky Test

### DIFF
--- a/test/chip8/instruction/jp_test.exs
+++ b/test/chip8/instruction/jp_test.exs
@@ -38,7 +38,7 @@ defmodule Chip8.Instruction.JPTest do
       runtime = put_in(runtime.v, v_registers)
 
       v0 = Register.v(0x0)
-      address = %Address{value: :rand.uniform(0xFFF)}
+      address = %Address{value: :rand.uniform(0xFFF) - register_value}
       arguments = {v0, address}
       executed_runtime = JP.execute(runtime, arguments)
 


### PR DESCRIPTION
### Why is this PR necessary?
One of the tests for `JP V0, address` is failing from time to time, it needs to be fixed in order to be reliable and break only when something is wrong with the instruction logic.

### What could go wrong?
The test data was changed in order to not overflow 12-bits but it might change the scenario as a whole so there's a need to make sure that the test is still valid.

### What other approaches did you consider? Why did you decide on this approach?
I decide to subtract the current `V0` value in order to ensure that it wasn't possible to overflow and the assert passes as expected. One thing to note is that the code already handles this scenario so the only problem is the test value that we used to ensure that the result was correct.


