### PR TITLE
Move Stack Module

### DIFF
--- a/lib/chip8/runtime.ex
+++ b/lib/chip8/runtime.ex
@@ -6,9 +6,9 @@ defmodule Chip8.Runtime do
   alias Chip8.Runtime.Instruction
   alias Chip8.Runtime.Keyboard
   alias Chip8.Runtime.Memory
-  alias Chip8.Runtime.Stack
   alias Chip8.Runtime.Timer
   alias Chip8.Runtime.VRegisters
+  alias Chip8.Stack
   alias Chip8.UInt
 
   @enforce_keys [:display, :dt, :i, :keyboard, :memory, :pc, :st, :stack, :v]

--- a/lib/chip8/runtime/instruction/call.ex
+++ b/lib/chip8/runtime/instruction/call.ex
@@ -5,7 +5,7 @@ defmodule Chip8.Runtime.Instruction.CALL do
 
   alias Chip8.Runtime
   alias Chip8.Runtime.Instruction.Argument.Address
-  alias Chip8.Runtime.Stack
+  alias Chip8.Stack
 
   @impl Chip8.Runtime.Instruction
   def execute(%Runtime{} = runtime, {%Address{} = address}) do

--- a/lib/chip8/runtime/instruction/ret.ex
+++ b/lib/chip8/runtime/instruction/ret.ex
@@ -4,7 +4,7 @@ defmodule Chip8.Runtime.Instruction.RET do
   use Chip8.Runtime.Instruction
 
   alias Chip8.Runtime
-  alias Chip8.Runtime.Stack
+  alias Chip8.Stack
 
   @impl Chip8.Runtime.Instruction
   def execute(%Runtime{} = runtime, {}) do

--- a/lib/chip8/stack.ex
+++ b/lib/chip8/stack.ex
@@ -1,4 +1,4 @@
-defmodule Chip8.Runtime.Stack do
+defmodule Chip8.Stack do
   @moduledoc false
 
   @enforce_keys [:data, :size]

--- a/test/chip8/runtime/instruction/ret_test.exs
+++ b/test/chip8/runtime/instruction/ret_test.exs
@@ -3,7 +3,7 @@ defmodule Chip8.Runtime.Instruction.RETTest do
 
   alias Chip8.Runtime
   alias Chip8.Runtime.Instruction.RET
-  alias Chip8.Runtime.Stack
+  alias Chip8.Stack
 
   describe "execute/2" do
     test "should return a runtime with pc set to the last item in the stack" do

--- a/test/chip8/stack_test.exs
+++ b/test/chip8/stack_test.exs
@@ -1,7 +1,7 @@
-defmodule Chip8.Runtime.StackTest do
+defmodule Chip8.StackTest do
   use ExUnit.Case, async: true
 
-  alias Chip8.Runtime.Stack
+  alias Chip8.Stack
 
   describe "new/0" do
     test "should return a stack struct" do


### PR DESCRIPTION
### Why is this PR necessary?
During https://github.com/cgerling/chip-8/pull/32 the `Stack` module was moved to be inside the `Chip8.Runtime` context but after some consideration this should not have been moved to there, this PR aims to revert that specific change.

### What could go wrong?
Nothing, it's a simple change to the module _namespace_ that is both covered by tests and the Elixir compiler.

### What other approaches did you consider? Why did you decide on this approach?
The `Stack` module is aimed to be a generic implementation of a stack data structure and does not have any specific behavior related to the Chip8 details (e.g. limiting the amount of items to 12) so it doesn't seem that it should be located inside the `Chip8.Runtime` namespace.

