### PR TITLE
Add source_url to Docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,6 +2,7 @@ defmodule Chip8.MixProject do
   use Mix.Project
 
   @version "0.1.0"
+  @repository_url "https://github.com/cgerling/chip-8"
 
   def project do
     [
@@ -39,7 +40,7 @@ defmodule Chip8.MixProject do
     [
       exclude_patterns: ["priv/plts"],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/cgerling/chip-8"}
+      links: %{"GitHub" => @repository_url}
     ]
   end
 
@@ -48,6 +49,7 @@ defmodule Chip8.MixProject do
       main: "readme",
       extras: ["README.md"],
       source_ref: "v#{@version}",
+      source_url: @repository_url,
       groups_for_modules: [
         Interpreter: [
           Chip8.Interpreter.Display,


### PR DESCRIPTION
### Why is this PR necessary?
Use the `source_url` option to pass the repository url to ExDoc, allowing people to easily check the source code of the project.

### What could go wrong?
Nothing, this simply adds a new configuration to ExDoc.

### What other approaches did you consider? Why did you decide on this approach?
I followed ExDocs documentation to find out this option and how to use it.

