### PR TITLE
Use Maps to store Interpreter Component's internal data

### DIFF
--- a/lib/chip8/interpreter/display/coordinates.ex
+++ b/lib/chip8/interpreter/display/coordinates.ex
@@ -1,0 +1,35 @@
+defmodule Chip8.Interpreter.Display.Coordinates do
+  @moduledoc false
+
+  @enforce_keys [:x, :y]
+  defstruct @enforce_keys
+
+  @type t() :: %__MODULE__{
+          x: integer(),
+          y: integer()
+        }
+
+  @spec new(integer(), integer()) :: t()
+  def new(x, y) when is_integer(x) and is_integer(y) do
+    %__MODULE__{
+      x: x,
+      y: y
+    }
+  end
+
+  @spec add(t(), t()) :: t()
+  def add(%__MODULE__{} = a, %__MODULE__{} = b) do
+    x = a.x + b.x
+    y = a.y + b.y
+
+    new(x, y)
+  end
+
+  @spec from_ordinal(non_neg_integer(), pos_integer()) :: t()
+  def from_ordinal(ordinal, max_y) when is_integer(ordinal) and is_integer(max_y) do
+    x = rem(ordinal, max_y)
+    y = Integer.floor_div(ordinal, max_y)
+
+    new(x, y)
+  end
+end

--- a/lib/chip8/interpreter/display/sprite.ex
+++ b/lib/chip8/interpreter/display/sprite.ex
@@ -13,11 +13,13 @@ defmodule Chip8.Interpreter.Display.Sprite do
   `Chip8.Interpreter.Font` for more information.
   """
 
+  alias Chip8.Interpreter.Display.Coordinates
+
   @enforce_keys [:data]
   defstruct @enforce_keys
 
   @type bit() :: 0 | 1
-  @type bitmap() :: [[bit(), ...], ...]
+  @type bitmap() :: [{Coordinates.t(), bit()}]
   @type data() :: [byte(), ...]
 
   @type t() :: %__MODULE__{
@@ -51,6 +53,10 @@ defmodule Chip8.Interpreter.Display.Sprite do
 
   @spec to_bitmap(t()) :: bitmap()
   def to_bitmap(%__MODULE__{data: data}) do
-    Enum.chunk_every(data, @width)
+    data
+    |> Enum.with_index()
+    |> Enum.map(fn {bit, index} ->
+      {Coordinates.from_ordinal(index, @width), bit}
+    end)
   end
 end

--- a/lib/chip8/interpreter/display/sprite.ex
+++ b/lib/chip8/interpreter/display/sprite.ex
@@ -25,9 +25,12 @@ defmodule Chip8.Interpreter.Display.Sprite do
         }
 
   @width 8
+  @max_height 15
 
   @spec new(data()) :: t()
   def new(data) when is_list(data) do
+    data = Enum.slice(data, 0, @max_height)
+
     %__MODULE__{
       data: data
     }

--- a/lib/chip8/interpreter/display/sprite.ex
+++ b/lib/chip8/interpreter/display/sprite.ex
@@ -21,7 +21,7 @@ defmodule Chip8.Interpreter.Display.Sprite do
   @type data() :: [byte(), ...]
 
   @type t() :: %__MODULE__{
-          data: data()
+          data: [bit()]
         }
 
   @width 8
@@ -29,22 +29,28 @@ defmodule Chip8.Interpreter.Display.Sprite do
 
   @spec new(data()) :: t()
   def new(data) when is_list(data) do
-    data = Enum.slice(data, 0, @max_height)
+    data =
+      data
+      |> Enum.slice(0, @max_height)
+      |> Enum.map(&to_bits/1)
+      |> List.flatten()
 
     %__MODULE__{
       data: data
     }
   end
 
+  defp to_bits(byte) do
+    bits = Integer.digits(byte, 2)
+
+    padding_amount = @width - Enum.count(bits)
+    padding = List.duplicate(0, padding_amount)
+
+    List.flatten([padding | bits])
+  end
+
   @spec to_bitmap(t()) :: bitmap()
   def to_bitmap(%__MODULE__{data: data}) do
-    Enum.map(data, fn byte ->
-      bits = Integer.digits(byte, 2)
-
-      padding_amount = @width - Enum.count(bits)
-      padding = List.duplicate(0, padding_amount)
-
-      List.flatten([padding | bits])
-    end)
+    Enum.chunk_every(data, @width)
   end
 end

--- a/test/chip8/interpreter/display/coordinates_test.exs
+++ b/test/chip8/interpreter/display/coordinates_test.exs
@@ -1,0 +1,50 @@
+defmodule Chip8.Interpreter.Display.CoordinatesTest do
+  use ExUnit.Case, async: true
+
+  alias Chip8.Interpreter.Display.Coordinates
+
+  describe "new/1" do
+    test "should return a coordinates struct" do
+      x = :rand.uniform(1000)
+      y = :rand.uniform(1000)
+      coordinates = Coordinates.new(x, y)
+
+      assert %Coordinates{} = coordinates
+      assert coordinates.x == x
+      assert coordinates.y == y
+    end
+  end
+
+  describe "add/2" do
+    test "should return a coordinates struct with both axis added up" do
+      x_a = :rand.uniform(1000)
+      y_a = :rand.uniform(1000)
+      coordinates_a = Coordinates.new(x_a, y_a)
+
+      x_b = :rand.uniform(1000)
+      y_b = :rand.uniform(1000)
+      coordinates_b = Coordinates.new(x_b, y_b)
+
+      coordinates = Coordinates.add(coordinates_a, coordinates_b)
+      assert %Coordinates{} = coordinates
+      assert coordinates.x == x_a + x_b
+      assert coordinates.y == y_a + y_b
+    end
+  end
+
+  describe "from_ordinal/2" do
+    test "should return a coordinates struct based in the given ordinal" do
+      ordinal = 8
+      max_y = 20
+
+      assert Coordinates.from_ordinal(ordinal, max_y) == Coordinates.new(8, 0)
+    end
+
+    test "should return a coordinates struct when ordinal is greater than the given maximum y value" do
+      ordinal = 35
+      max_y = 20
+
+      assert Coordinates.from_ordinal(ordinal, max_y) == Coordinates.new(15, 1)
+    end
+  end
+end

--- a/test/chip8/interpreter/display/sprite_test.exs
+++ b/test/chip8/interpreter/display/sprite_test.exs
@@ -14,7 +14,7 @@ defmodule Chip8.Interpreter.Display.SpriteTest do
       overflow_data = List.duplicate(0xFF, 20)
       sprite = Sprite.new(overflow_data)
 
-      assert Enum.count(sprite.data) == 15
+      assert Enum.count(sprite.data) == 15 * 8
     end
   end
 

--- a/test/chip8/interpreter/display/sprite_test.exs
+++ b/test/chip8/interpreter/display/sprite_test.exs
@@ -9,6 +9,13 @@ defmodule Chip8.Interpreter.Display.SpriteTest do
 
       assert %Sprite{} = sprite
     end
+
+    test "should return a sprite struct with data trimmed when data is bigger than the a sprite limit" do
+      overflow_data = List.duplicate(0xFF, 20)
+      sprite = Sprite.new(overflow_data)
+
+      assert Enum.count(sprite.data) == 15
+    end
   end
 
   describe "to_bitmap/1" do

--- a/test/chip8/interpreter/display_test.exs
+++ b/test/chip8/interpreter/display_test.exs
@@ -2,6 +2,7 @@ defmodule Chip8.Interpreter.DisplayTest do
   use ExUnit.Case, async: true
 
   alias Chip8.Interpreter.Display
+  alias Chip8.Interpreter.Display.Coordinates
   alias Chip8.Interpreter.Display.Sprite
 
   describe "new/2" do
@@ -17,7 +18,7 @@ defmodule Chip8.Interpreter.DisplayTest do
   describe "clear/1" do
     test "should return a display struct with all pixels off" do
       sprite = 0xFF |> List.duplicate(15) |> Sprite.new()
-      coordinates = {0, 0}
+      coordinates = Coordinates.new(0, 0)
 
       display = Display.new(10, 10)
       display = Display.draw(display, coordinates, sprite)
@@ -52,7 +53,7 @@ defmodule Chip8.Interpreter.DisplayTest do
 
       coordinates = Display.get_coordinates(display, x, y)
 
-      assert {x, y} == coordinates
+      assert Coordinates.new(x, y) == coordinates
     end
 
     test "should return a coordinates tuple wrapped when x is equals to display's width" do
@@ -62,7 +63,7 @@ defmodule Chip8.Interpreter.DisplayTest do
 
       coordinates = Display.get_coordinates(display, x, y)
 
-      assert {0, y} == coordinates
+      assert Coordinates.new(0, y) == coordinates
     end
 
     test "should return a coordinates tuple wrapped when x is greather than display's width" do
@@ -74,7 +75,7 @@ defmodule Chip8.Interpreter.DisplayTest do
 
       coordinates = Display.get_coordinates(display, overflow_x, y)
 
-      assert {x, y} == coordinates
+      assert Coordinates.new(x, y) == coordinates
     end
 
     test "should return a coordinates tuple wrapped when y is equals to display's height" do
@@ -84,7 +85,7 @@ defmodule Chip8.Interpreter.DisplayTest do
 
       coordinates = Display.get_coordinates(display, x, y)
 
-      assert {x, 0} == coordinates
+      assert Coordinates.new(x, 0) == coordinates
     end
 
     test "should return a coordinates tuple wrapped when y is greather than display's height" do
@@ -96,7 +97,7 @@ defmodule Chip8.Interpreter.DisplayTest do
 
       coordinates = Display.get_coordinates(display, x, overflow_y)
 
-      assert {x, y} == coordinates
+      assert Coordinates.new(x, y) == coordinates
     end
   end
 
@@ -104,7 +105,7 @@ defmodule Chip8.Interpreter.DisplayTest do
     test "should return a display struct with sprite rendered into the given coordinates" do
       display = Display.new(8, 8)
       sprite = Sprite.new([0xAA, 0x55, 0xAA, 0x55])
-      coordinates = {0, 2}
+      coordinates = Coordinates.new(0, 2)
 
       drawed_display = Display.draw(display, coordinates, sprite)
 
@@ -125,7 +126,7 @@ defmodule Chip8.Interpreter.DisplayTest do
     test "should return a display struct with the sprite erased when rendered twice into the same coordinates" do
       display = Display.new(8, 8)
       sprite = Sprite.new([0xAA, 0x55, 0xAA, 0x55])
-      coordinates = {0, 2}
+      coordinates = Coordinates.new(0, 2)
 
       display = Display.draw(display, coordinates, sprite)
 
@@ -148,7 +149,7 @@ defmodule Chip8.Interpreter.DisplayTest do
     test "should return a display struct with the sprite cropped horizontally when it overflows the display's width" do
       display = Display.new(8, 8)
       sprite = Sprite.new([0xFF, 0xFF])
-      coordinates = {4, 0}
+      coordinates = Coordinates.new(4, 0)
 
       drawed_display = Display.draw(display, coordinates, sprite)
 
@@ -169,7 +170,7 @@ defmodule Chip8.Interpreter.DisplayTest do
     test "should return a display struct with the sprite cropped vertically when it overflows the display's height" do
       display = Display.new(8, 8)
       sprite = Sprite.new([0x0F, 0x0F, 0x0F, 0x0F])
-      coordinates = {0, 6}
+      coordinates = Coordinates.new(0, 6)
 
       drawed_display = Display.draw(display, coordinates, sprite)
 
@@ -191,7 +192,7 @@ defmodule Chip8.Interpreter.DisplayTest do
   describe "has_collision?/2" do
     test "should return true when any of the pixels on in the before display are off in the after display" do
       display = Display.new(8, 8)
-      coordinates = {0, 0}
+      coordinates = Coordinates.new(0, 0)
       sprite = Sprite.new([0x1])
 
       before_display = Display.draw(display, coordinates, sprite)

--- a/test/chip8/interpreter/display_test.exs
+++ b/test/chip8/interpreter/display_test.exs
@@ -16,9 +16,11 @@ defmodule Chip8.Interpreter.DisplayTest do
 
   describe "clear/1" do
     test "should return a display struct with all pixels off" do
+      sprite = 0xFF |> List.duplicate(15) |> Sprite.new()
+      coordinates = {0, 0}
+
       display = Display.new(10, 10)
-      filled_pixels = List.duplicate(1, display.height * display.width)
-      display = %{display | pixels: filled_pixels}
+      display = Display.draw(display, coordinates, sprite)
 
       cleared_display = Display.clear(display)
 

--- a/test/chip8/interpreter/instruction/drw_test.exs
+++ b/test/chip8/interpreter/instruction/drw_test.exs
@@ -22,10 +22,11 @@ defmodule Chip8.Interpreter.Instruction.DRWTest do
       arguments = {vx, vy, nibble}
       executed_interpreter = DRW.execute(interpreter, arguments)
 
-      sprite_rendered_pixels = Enum.slice(executed_interpreter.display.pixels, 0, 8)
+      sprite_rendered_pixels =
+        executed_interpreter.display |> Display.pixelmap() |> List.first() |> Enum.slice(0, 8)
 
       assert %Interpreter{} = executed_interpreter
-      assert [1, 1, 0, 1, 1, 0, 0, 1] == sprite_rendered_pixels
+      assert sprite_rendered_pixels == [1, 1, 0, 1, 1, 0, 0, 1]
     end
 
     test "should return an interpreter with VF set to 0 when there was no pixel collision" do

--- a/test/chip8/interpreter/instruction/drw_test.exs
+++ b/test/chip8/interpreter/instruction/drw_test.exs
@@ -3,6 +3,7 @@ defmodule Chip8.Interpreter.Instruction.DRWTest do
 
   alias Chip8.Interpreter
   alias Chip8.Interpreter.Display
+  alias Chip8.Interpreter.Display.Coordinates
   alias Chip8.Interpreter.Instruction.Argument.Nibble
   alias Chip8.Interpreter.Instruction.Argument.Register
   alias Chip8.Interpreter.Instruction.DRW
@@ -50,7 +51,8 @@ defmodule Chip8.Interpreter.Instruction.DRWTest do
       memory = Memory.write(interpreter.memory, i, sprite_data)
       interpreter = put_in(interpreter.memory, memory)
       sprite = Display.create_sprite(sprite_data)
-      display = Display.draw(interpreter.display, {0, 0}, sprite)
+      coordinates = Coordinates.new(0, 0)
+      display = Display.draw(interpreter.display, coordinates, sprite)
       interpreter = put_in(interpreter.display, display)
 
       vx = %Register{value: 0}

--- a/test/chip8/interpreter/memory_test.exs
+++ b/test/chip8/interpreter/memory_test.exs
@@ -89,7 +89,7 @@ defmodule Chip8.Interpreter.MemoryTest do
       written_memory = Memory.write(memory, address, data)
 
       assert %Memory{} = written_memory
-      assert [1, 2, 3, 4, 5, 0, 0, 0, 0, 0] == written_memory.data
+      assert written_memory.data == memory_data([1, 2, 3, 4, 5, 0, 0, 0, 0, 0])
     end
 
     test "should return a memory struct with data truncated on the given address when data overflows memory" do
@@ -101,7 +101,13 @@ defmodule Chip8.Interpreter.MemoryTest do
       written_memory = Memory.write(memory, address, data)
 
       assert %Memory{} = written_memory
-      assert [0, 0, 0, 0, 0, 0, 1, 2, 3, 4] == written_memory.data
+      assert written_memory.data == memory_data([0, 0, 0, 0, 0, 0, 1, 2, 3, 4])
     end
+  end
+
+  defp memory_data(list) do
+    list
+    |> Enum.with_index()
+    |> Map.new(fn {value, index} -> {index, value} end)
   end
 end


### PR DESCRIPTION
### Why is this PR necessary?
This PR improves the performance of operations related to the `Display` and `Memory` components by changing their internal data structure, allowing the simplification of their internal logic because there are fewer hoops to jump across to reach the desired result.

### What could go wrong?
The new logic might add or remove implicit behaviors that programs were reling on, this is a common issue with old programs due to the platform's lack of documentation and the programs' hacky nature.

### What other approaches did you consider? Why did you decide on this approach?
Initially, I thought about using Erlang's `:array` data structure, but while running some benchmarks they performed similarly with regular maps with the caveat of not having the `Enum` ergonomics and the flexibility to define a custom key, which proved to be valuable for the `Display` component.

