### PR TITLE
Create function to verify a Timer's state

### DIFF
--- a/lib/chip8.ex
+++ b/lib/chip8.ex
@@ -117,4 +117,22 @@ defmodule Chip8 do
   """
   @spec tick_timers(Interpreter.t()) :: Interpreter.t()
   defdelegate tick_timers(interpreter), to: Interpreter
+
+  @doc """
+  Returns a `boolean()` representing the current state of the given timer.
+  This is usefull to run custom logic based on a timer state, for example
+  emitting sound when the sound timer is active.
+
+  See `Chip8.Interpreter.Timer` for more information on timers.
+
+  ```elixir
+    iex> Chip8.is_timer_active?(interpreter, :dt)
+    false
+
+    iex> Chip8.is_timer_active?(interpreter, :st)
+    true
+  ```
+  """
+  @spec is_timer_active?(Interpreter.t(), Interpreter.timers()) :: boolean()
+  defdelegate is_timer_active?(interpreter, timer), to: Interpreter
 end

--- a/lib/chip8/interpreter.ex
+++ b/lib/chip8/interpreter.ex
@@ -49,6 +49,7 @@ defmodule Chip8.Interpreter do
   @enforce_keys [:cycle_rate, :display, :dt, :i, :keyboard, :memory, :pc, :st, :stack, :v]
   defstruct @enforce_keys
 
+  @type timers() :: :dt | :st
   @type t() :: %__MODULE__{
           cycle_rate: pos_integer(),
           display: Display.t(),
@@ -196,5 +197,14 @@ defmodule Chip8.Interpreter do
   def change_cycle_rate(%__MODULE__{} = interpreter, cycle_rate)
       when is_integer(cycle_rate) and cycle_rate > 0 do
     %{interpreter | cycle_rate: cycle_rate}
+  end
+
+  @spec is_timer_active?(t(), timers()) :: boolean()
+  def is_timer_active?(%__MODULE__{} = interpreter, :dt) do
+    Timer.active?(interpreter.dt)
+  end
+
+  def is_timer_active?(%__MODULE__{} = interpreter, :st) do
+    Timer.active?(interpreter.st)
   end
 end

--- a/lib/chip8/interpreter/timer.ex
+++ b/lib/chip8/interpreter/timer.ex
@@ -36,4 +36,9 @@ defmodule Chip8.Interpreter.Timer do
 
     %{timer | value: value}
   end
+
+  @spec active?(t()) :: boolean()
+  def active?(%__MODULE__{} = timer) do
+    timer.value > 0
+  end
 end

--- a/test/chip8/interpreter/timer_test.exs
+++ b/test/chip8/interpreter/timer_test.exs
@@ -47,4 +47,19 @@ defmodule Chip8.Interpreter.TimerTest do
       assert ticked_timer == Timer.new()
     end
   end
+
+  describe "active?/1" do
+    test "should return true when timer value is greater than 0" do
+      value = :rand.uniform(0xFFFF) + 1
+      timer = Timer.new(value)
+
+      assert Timer.active?(timer)
+    end
+
+    test "should return false when timer value is equals to 0" do
+      timer = Timer.new(0)
+
+      refute Timer.active?(timer)
+    end
+  end
 end

--- a/test/chip8/interpreter_test.exs
+++ b/test/chip8/interpreter_test.exs
@@ -358,4 +358,36 @@ defmodule Chip8.InterpreterTest do
       assert changed_interpreter.cycle_rate == 1
     end
   end
+
+  describe "is_timer_active?/2" do
+    test "should return true when the display timer has a value greater than 0" do
+      value = :rand.uniform(0xFFFF) + 1
+      interpreter = Interpreter.new()
+      interpreter = put_in(interpreter.dt, Timer.new(value))
+
+      assert Interpreter.is_timer_active?(interpreter, :dt)
+    end
+
+    test "should return true when the display timer has a value equals to 0" do
+      interpreter = Interpreter.new()
+      interpreter = put_in(interpreter.dt, Timer.new(0))
+
+      refute Interpreter.is_timer_active?(interpreter, :dt)
+    end
+
+    test "should return true when the sound timer has a value greater than 0" do
+      value = :rand.uniform(0xFFFF) + 1
+      interpreter = Interpreter.new()
+      interpreter = put_in(interpreter.st, Timer.new(value))
+
+      assert Interpreter.is_timer_active?(interpreter, :st)
+    end
+
+    test "should return true when the sound timer has a value equals to 0" do
+      interpreter = Interpreter.new()
+      interpreter = put_in(interpreter.st, Timer.new(0))
+
+      refute Interpreter.is_timer_active?(interpreter, :st)
+    end
+  end
 end


### PR DESCRIPTION
### Why is this PR necessary?
Generating sound is one of the many responsibilities that a front-end have, but in order for that to be possible, such applications need a way to detect when a timer is active to emit a tone. This PR introduces the logic required to verify whether or not a timer is active, including the `sound timer`.

### What could go wrong?
Since this is an addition to the public API it's required to be sure about the function's contract.

### What other approaches did you consider? Why did you decide on this approach?
This API came from a front-end that was doing the verification logic itself, after some iterations this was the result.

