### PR TITLE
Optimize Display internal logic

### DIFF
--- a/lib/chip8.ex
+++ b/lib/chip8.ex
@@ -135,4 +135,26 @@ defmodule Chip8 do
   """
   @spec is_timer_active?(Interpreter.t(), Interpreter.timers()) :: boolean()
   defdelegate is_timer_active?(interpreter, timer), to: Interpreter
+
+  @doc """
+  Returns a list containing all the pixels from the second interpreter that has
+  a different state from their equivalent pixels on the first interpreter. The
+  list is composed of tuples, each tuple has its first element being the
+  pixel's coordinates (`t:Display.Coordinates.t/0`) and the second element is
+  the state they have in the second interpreter.
+
+  This is useful when rendering only the pixels that changed during a cycle.
+
+  ```elixir
+    iex> interpreter = Chip8.initialize()
+    iex> Chip8.display_changes(interpreter, interpreter)
+    []
+
+    iex> cycled_interpreter = Chip8.cycle(interpreter)
+    iex> Chip8.display_changes(interpreter, cycled_interpreter)
+    [...]
+  ```
+  """
+  @spec display_changes(Interpreter.t(), Interpreter.t()) :: Display.diff()
+  defdelegate display_changes(interpreter_a, interpreter_b), to: Interpreter
 end

--- a/lib/chip8/interpreter.ex
+++ b/lib/chip8/interpreter.ex
@@ -207,4 +207,9 @@ defmodule Chip8.Interpreter do
   def is_timer_active?(%__MODULE__{} = interpreter, :st) do
     Timer.active?(interpreter.st)
   end
+
+  @spec display_changes(t(), t()) :: Display.diff()
+  def display_changes(%__MODULE__{} = interpreter_a, %__MODULE__{} = interpreter_b) do
+    Display.diff(interpreter_a.display, interpreter_b.display)
+  end
 end

--- a/lib/chip8/interpreter/display.ex
+++ b/lib/chip8/interpreter/display.ex
@@ -28,6 +28,7 @@ defmodule Chip8.Interpreter.Display do
   @type dimension() :: non_neg_integer()
   @type pixel() :: 0 | 1
   @type pixelmap() :: [[pixel(), ...], ...]
+  @type diff() :: [{Coordinates.t(), pixel()}]
 
   @type t() :: %__MODULE__{
           height: dimension(),
@@ -100,5 +101,15 @@ defmodule Chip8.Interpreter.Display do
         Map.fetch!(pixels, coordinates)
       end
     end
+  end
+
+  @spec diff(t(), t()) :: diff()
+  def diff(%__MODULE__{} = before_display, %__MODULE__{} = after_display) do
+    before_pixels = before_display.pixels
+    after_pixels = after_display.pixels
+
+    after_pixels
+    |> Map.reject(fn {coordinates, pixel} -> pixel == before_pixels[coordinates] end)
+    |> Enum.to_list()
   end
 end

--- a/lib/chip8/interpreter/display.ex
+++ b/lib/chip8/interpreter/display.ex
@@ -60,7 +60,7 @@ defmodule Chip8.Interpreter.Display do
     Coordinates.new(x, y)
   end
 
-  @spec draw(t(), Coordinates.t(), Sprite.t()) :: t()
+  @spec draw(t(), Coordinates.t(), Sprite.t()) :: {t(), boolean()}
   def draw(%__MODULE__{} = display, {x, y} = coordinates, %Sprite{} = sprite)
       when Coordinates.is_coordinates(coordinates) do
     visible_width = max(display.width - x, 0)
@@ -75,7 +75,9 @@ defmodule Chip8.Interpreter.Display do
         Map.update!(pixels, pixel_coordinates, &Bitwise.bxor(&1, bit))
       end)
 
-    %{display | pixels: pixels}
+    new_display = %{display | pixels: pixels}
+    collision? = has_collision?(display, new_display)
+    {new_display, collision?}
   end
 
   @spec has_collision?(t(), t()) :: boolean()

--- a/lib/chip8/interpreter/display.ex
+++ b/lib/chip8/interpreter/display.ex
@@ -20,6 +20,8 @@ defmodule Chip8.Interpreter.Display do
   alias Chip8.Interpreter.Display.Coordinates
   alias Chip8.Interpreter.Display.Sprite
 
+  require Coordinates
+
   @enforce_keys [:height, :pixels, :width]
   defstruct @enforce_keys
 
@@ -59,16 +61,15 @@ defmodule Chip8.Interpreter.Display do
   end
 
   @spec draw(t(), Coordinates.t(), Sprite.t()) :: t()
-  def draw(%__MODULE__{} = display, %Coordinates{} = coordinates, %Sprite{} = sprite) do
-    visible_width = max(display.width - coordinates.x, 0)
-    visible_height = max(display.height - coordinates.y, 0)
+  def draw(%__MODULE__{} = display, {x, y} = coordinates, %Sprite{} = sprite)
+      when Coordinates.is_coordinates(coordinates) do
+    visible_width = max(display.width - x, 0)
+    visible_height = max(display.height - y, 0)
 
     pixels =
       sprite
       |> Sprite.to_bitmap()
-      |> Enum.filter(fn {coordinates, _} ->
-        coordinates.x < visible_width and coordinates.y < visible_height
-      end)
+      |> Enum.filter(fn {{x, y}, _} -> x < visible_width and y < visible_height end)
       |> Enum.reduce(display.pixels, fn {bit_coordinates, bit}, pixels ->
         pixel_coordinates = Coordinates.add(coordinates, bit_coordinates)
         Map.update!(pixels, pixel_coordinates, &Bitwise.bxor(&1, bit))

--- a/lib/chip8/interpreter/display.ex
+++ b/lib/chip8/interpreter/display.ex
@@ -78,10 +78,16 @@ defmodule Chip8.Interpreter.Display do
   end
 
   @spec has_collision?(t(), t()) :: boolean()
-  def has_collision?(%__MODULE__{pixels: before_pixels}, %__MODULE__{pixels: after_pixels}) do
-    before_pixels
-    |> Enum.zip(after_pixels)
-    |> Enum.any?(fn {before_pixel, after_pixel} -> before_pixel > after_pixel end)
+  def has_collision?(%__MODULE__{} = before_display, %__MODULE__{} = after_display) do
+    last_pixel = before_display.height * before_display.width - 1
+
+    Enum.reduce_while(0..last_pixel, false, fn pixel_index, _ ->
+      coordinates = Coordinates.from_ordinal(pixel_index, before_display.width)
+      before_pixel = before_display.pixels[coordinates]
+      after_pixel = after_display.pixels[coordinates]
+
+      if before_pixel > after_pixel, do: {:halt, true}, else: {:cont, false}
+    end)
   end
 
   @spec create_sprite(Sprite.data()) :: Sprite.t()

--- a/lib/chip8/interpreter/display/coordinates.ex
+++ b/lib/chip8/interpreter/display/coordinates.ex
@@ -1,5 +1,12 @@
 defmodule Chip8.Interpreter.Display.Coordinates do
-  @moduledoc false
+  @moduledoc """
+  Internal module used by `Chip8.Interpreter.Display` to make easier to
+  manipulate the tuples representing the pixel coordinates.
+
+  The Coordinates value is a tuple containing two integer values. The first is
+  the value of the x-axis (horizontal) and the second is the value of the
+  y-axis (vertical).
+  """
 
   @enforce_keys [:x, :y]
   defstruct @enforce_keys

--- a/lib/chip8/interpreter/display/coordinates.ex
+++ b/lib/chip8/interpreter/display/coordinates.ex
@@ -4,23 +4,21 @@ defmodule Chip8.Interpreter.Display.Coordinates do
   @enforce_keys [:x, :y]
   defstruct @enforce_keys
 
-  @type t() :: %__MODULE__{
-          x: integer(),
-          y: integer()
-        }
+  @type t() :: {x :: integer(), y :: integer()}
+
+  defguard is_coordinates(coordinates)
+           when is_tuple(coordinates) and is_integer(elem(coordinates, 0)) and
+                  is_integer(elem(coordinates, 1))
 
   @spec new(integer(), integer()) :: t()
   def new(x, y) when is_integer(x) and is_integer(y) do
-    %__MODULE__{
-      x: x,
-      y: y
-    }
+    {x, y}
   end
 
   @spec add(t(), t()) :: t()
-  def add(%__MODULE__{} = a, %__MODULE__{} = b) do
-    x = a.x + b.x
-    y = a.y + b.y
+  def add({a_x, a_y}, {b_x, b_y}) do
+    x = a_x + b_x
+    y = a_y + b_y
 
     new(x, y)
   end

--- a/lib/chip8/interpreter/instruction/drw.ex
+++ b/lib/chip8/interpreter/instruction/drw.ex
@@ -40,9 +40,9 @@ defmodule Chip8.Interpreter.Instruction.DRW do
     coordinates =
       Display.get_coordinates(interpreter.display, interpreter.v[x.value], interpreter.v[y.value])
 
-    drawed_display = Display.draw(interpreter.display, coordinates, sprite)
+    {drawed_display, collision?} = Display.draw(interpreter.display, coordinates, sprite)
 
-    collision = if Display.has_collision?(interpreter.display, drawed_display), do: 1, else: 0
+    collision = if collision?, do: 1, else: 0
     v_registers = VRegisters.set(interpreter.v, 0xF, collision)
     %{interpreter | display: drawed_display, v: v_registers}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -53,6 +53,7 @@ defmodule Chip8.MixProject do
       groups_for_modules: [
         Interpreter: [
           Chip8.Interpreter.Display,
+          Chip8.Interpreter.Display.Coordinates,
           Chip8.Interpreter.Display.Sprite,
           Chip8.Interpreter.Font,
           Chip8.Interpreter.Instruction,

--- a/test/chip8/interpreter/display/coordinates_test.exs
+++ b/test/chip8/interpreter/display/coordinates_test.exs
@@ -7,11 +7,8 @@ defmodule Chip8.Interpreter.Display.CoordinatesTest do
     test "should return a coordinates struct" do
       x = :rand.uniform(1000)
       y = :rand.uniform(1000)
-      coordinates = Coordinates.new(x, y)
 
-      assert %Coordinates{} = coordinates
-      assert coordinates.x == x
-      assert coordinates.y == y
+      assert {^x, ^y} = Coordinates.new(x, y)
     end
   end
 
@@ -25,10 +22,9 @@ defmodule Chip8.Interpreter.Display.CoordinatesTest do
       y_b = :rand.uniform(1000)
       coordinates_b = Coordinates.new(x_b, y_b)
 
-      coordinates = Coordinates.add(coordinates_a, coordinates_b)
-      assert %Coordinates{} = coordinates
-      assert coordinates.x == x_a + x_b
-      assert coordinates.y == y_a + y_b
+      assert {x, y} = Coordinates.add(coordinates_a, coordinates_b)
+      assert x == x_a + x_b
+      assert y == y_a + y_b
     end
   end
 

--- a/test/chip8/interpreter/display/sprite_test.exs
+++ b/test/chip8/interpreter/display/sprite_test.exs
@@ -4,6 +4,8 @@ defmodule Chip8.Interpreter.Display.SpriteTest do
   alias Chip8.Interpreter.Display.Coordinates
   alias Chip8.Interpreter.Display.Sprite
 
+  require Coordinates
+
   describe "new/1" do
     test "should return a sprite struct" do
       sprite = Sprite.new([])
@@ -26,7 +28,15 @@ defmodule Chip8.Interpreter.Display.SpriteTest do
       bitmap = Sprite.to_bitmap(sprite)
 
       assert is_list(bitmap)
-      assert Enum.all?(bitmap, &match?({%Coordinates{}, bit} when bit in [0, 1], &1))
+
+      assert Enum.all?(
+               bitmap,
+               &match?(
+                 {coordinates, bit}
+                 when Coordinates.is_coordinates(coordinates) and bit in [0, 1],
+                 &1
+               )
+             )
     end
 
     test "should return a list of bits with coordinates based on the sprite data" do

--- a/test/chip8/interpreter/display_test.exs
+++ b/test/chip8/interpreter/display_test.exs
@@ -21,7 +21,7 @@ defmodule Chip8.Interpreter.DisplayTest do
       coordinates = Coordinates.new(0, 0)
 
       display = Display.new(10, 10)
-      display = Display.draw(display, coordinates, sprite)
+      {display, _} = Display.draw(display, coordinates, sprite)
 
       cleared_display = Display.clear(display)
 
@@ -107,7 +107,7 @@ defmodule Chip8.Interpreter.DisplayTest do
       sprite = Sprite.new([0xAA, 0x55, 0xAA, 0x55])
       coordinates = Coordinates.new(0, 2)
 
-      drawed_display = Display.draw(display, coordinates, sprite)
+      {drawed_display, _collision} = Display.draw(display, coordinates, sprite)
 
       assert %Display{} = drawed_display
 
@@ -128,9 +128,9 @@ defmodule Chip8.Interpreter.DisplayTest do
       sprite = Sprite.new([0xAA, 0x55, 0xAA, 0x55])
       coordinates = Coordinates.new(0, 2)
 
-      display = Display.draw(display, coordinates, sprite)
+      {display, _collision} = Display.draw(display, coordinates, sprite)
 
-      drawed_display = Display.draw(display, coordinates, sprite)
+      {drawed_display, _collision} = Display.draw(display, coordinates, sprite)
 
       assert %Display{} = drawed_display
 
@@ -151,7 +151,7 @@ defmodule Chip8.Interpreter.DisplayTest do
       sprite = Sprite.new([0xFF, 0xFF])
       coordinates = Coordinates.new(4, 0)
 
-      drawed_display = Display.draw(display, coordinates, sprite)
+      {drawed_display, _collision} = Display.draw(display, coordinates, sprite)
 
       assert %Display{} = drawed_display
 
@@ -172,7 +172,7 @@ defmodule Chip8.Interpreter.DisplayTest do
       sprite = Sprite.new([0x0F, 0x0F, 0x0F, 0x0F])
       coordinates = Coordinates.new(0, 6)
 
-      drawed_display = Display.draw(display, coordinates, sprite)
+      {drawed_display, _collision} = Display.draw(display, coordinates, sprite)
 
       assert %Display{} = drawed_display
 
@@ -187,29 +187,22 @@ defmodule Chip8.Interpreter.DisplayTest do
                [0, 0, 0, 0, 1, 1, 1, 1]
              ]
     end
-  end
 
-  describe "has_collision?/2" do
-    test "should return true when any of the pixels on in the before display are off in the after display" do
+    test "should return collision flag as true when one of the display pixels was turned off while drawing the sprite" do
       display = Display.new(8, 8)
       coordinates = Coordinates.new(0, 0)
       sprite = Sprite.new([0x1])
 
-      before_display = Display.draw(display, coordinates, sprite)
-      after_display = Display.draw(before_display, coordinates, sprite)
-
-      has_collision? = Display.has_collision?(before_display, after_display)
-
-      assert has_collision?
+      {drawed_display, _collision} = Display.draw(display, coordinates, sprite)
+      assert {_display, true} = Display.draw(drawed_display, coordinates, sprite)
     end
 
-    test "should return false when all of the pixels on in the before display are still on in the after display" do
-      before_display = Display.new(8, 8)
-      after_display = Display.new(8, 8)
+    test "should return collision flag as false when no one of the display pixels was turned off while drawing the sprite" do
+      display = Display.new(8, 8)
+      coordinates = Coordinates.new(0, 0)
+      sprite = Sprite.new([0x1])
 
-      has_collision? = Display.has_collision?(before_display, after_display)
-
-      refute has_collision?
+      assert {_display, false} = Display.draw(display, coordinates, sprite)
     end
   end
 

--- a/test/chip8/interpreter/display_test.exs
+++ b/test/chip8/interpreter/display_test.exs
@@ -232,4 +232,23 @@ defmodule Chip8.Interpreter.DisplayTest do
              ]
     end
   end
+
+  describe "diff/2" do
+    test "should return a list with coordinates and the state of all pixels on the second display that has a different state from their equivalent ones on the first display" do
+      display = Display.new(8, 8)
+      sprite = Sprite.new([0x05, 0x05])
+      coordinates = Coordinates.new(0, 0)
+
+      {drawed_display, _} = Display.draw(display, coordinates, sprite)
+
+      diff_pixels = Display.diff(display, drawed_display)
+      assert Enum.sort(diff_pixels) == [{{5, 0}, 1}, {{5, 1}, 1}, {{7, 0}, 1}, {{7, 1}, 1}]
+    end
+
+    test "should return an empty list when there is no difference between the pixel's state between the first display and the second display" do
+      display = Display.new(8, 8)
+
+      assert Display.diff(display, display) == []
+    end
+  end
 end

--- a/test/chip8/interpreter/instruction/drw_test.exs
+++ b/test/chip8/interpreter/instruction/drw_test.exs
@@ -52,7 +52,7 @@ defmodule Chip8.Interpreter.Instruction.DRWTest do
       interpreter = put_in(interpreter.memory, memory)
       sprite = Display.create_sprite(sprite_data)
       coordinates = Coordinates.new(0, 0)
-      display = Display.draw(interpreter.display, coordinates, sprite)
+      {display, _} = Display.draw(interpreter.display, coordinates, sprite)
       interpreter = put_in(interpreter.display, display)
 
       vx = %Register{value: 0}

--- a/test/chip8/interpreter_test.exs
+++ b/test/chip8/interpreter_test.exs
@@ -390,4 +390,26 @@ defmodule Chip8.InterpreterTest do
       refute Interpreter.is_timer_active?(interpreter, :st)
     end
   end
+
+  describe "display_diff/2" do
+    test "should return a list with coordinates and the state of all pixels on the second interpreter's display that has a different state from their equivalent ones on the first interpreter's display" do
+      interpreter = Interpreter.new()
+
+      display = Display.new(8, 8)
+      sprite = Display.Sprite.new([0x05, 0x05])
+      coordinates = Display.Coordinates.new(0, 0)
+      {drawed_display, _} = Display.draw(display, coordinates, sprite)
+
+      drawed_interpreter = put_in(interpreter.display, drawed_display)
+
+      pixels_diff = Interpreter.display_changes(interpreter, drawed_interpreter)
+      assert Enum.sort(pixels_diff) == [{{5, 0}, 1}, {{5, 1}, 1}, {{7, 0}, 1}, {{7, 1}, 1}]
+    end
+
+    test "should return an empty list when there is no difference between the pixel's state between the first interpreter's display and the second interpreter's display" do
+      interpreter = Interpreter.new()
+
+      assert Interpreter.display_changes(interpreter, interpreter) == []
+    end
+  end
 end


### PR DESCRIPTION
### Why is this PR necessary?
This PR addresses a few pain points that have come up while developing a front end for this library:
* Change `Display.draw/3` to compute collisions during a draw call, removing the need to iterate through the whole display after each render
* Creating a diff logic to run partial updates on the display front-end implementation
  * Unnecessary transformations on the diff result due to using a struct to represent coordinates

### What could go wrong?
Once again, this was a major change in the Display's internal logic so, even though the test suite is passing and should be covering all use cases, some render artifacts could happen when running programs.

### What other approaches did you consider? Why did you decide on this approach?
While implementing the previous Display refactor that introduced the `Coordinates` struct I thought that maybe it should be a record rather than a struct. After reading a while about it, I came to the conclusion that structs would be the better option, but it was starting to require a lot of transformations during runtime, so I think that this PR hits a good spot. The `Coordinates` module became essentially a helper module, so it's easy and safe to handle such coordinate tuples, at the same time that there is no need to massage the data when exposed to a front-end.
And as for the `Display.draw/3` change, the fact that it was going through the whole display (in the worst case scenario) to detect something that could be detected for "free" during the draw call was starting to annoy me, so I decided to change it.
